### PR TITLE
Add label on non-author plugin changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 .env
+*.pem


### PR DESCRIPTION
See https://github.com/Nightfirecat/plugin-hub/pull/1 and https://github.com/Nightfirecat/plugin-hub/pull/2

The only thing this doesn't really cover is if a plugin commit descriptor has `authors=...` in its previous version but has it removed by a PR author--in that case, the `non-author plugin change` label would not be applied. I think that should be fine though.