### PR TITLE
Apply non-author tag only when plugins are changed

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -119,7 +119,7 @@ export = (app: Application) => {
 		let difftext = diffLines.join("\n\n");
 
 		const prAuthor = (await github.issues.get(context.issue())).data.user.login.toLowerCase();
-		if (!changedPluginAuthors.has(prAuthor)) {
+		if (changedPluginAuthors.size > 0 && !changedPluginAuthors.has(prAuthor)) {
 			difftext = "**Includes changes by non-author**\n\n" + difftext;
 			await setHasLabel(true, NON_AUTHOR_PLUGIN_CHANGE);
 		} else {


### PR DESCRIPTION
Prior to this commit, it was possible to submit a change which contained
only non-plugin changes (dependency and/or other files only) and be
incorrectly labeled as a non-author plugin change because
`changedPluginAuthors` was empty and thus could not contain the PR
author username.