### PR TITLE
fix disabled typo

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -123,7 +123,7 @@ export = (app: Probot) => {
 \`\`\`
 repository=...
 commit=...
-diabled=<Reason for disabling>
+disabled=<Reason for disabling>
 \`\`\``);
 			} else {
 				diffLines.push(`What is a \`${file.status}\`?`);


### PR DESCRIPTION
This fixes a typo introduced in the recent commit: https://github.com/runelite/runelite-github-app/commit/fbab9641a6576e487c56f7fd1557fd70c2660ee5