### PR TITLE
add link to diff new plugins against template

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -112,6 +112,7 @@ export = (app: Probot) => {
 				diffLines.push(`\`${pluginName}\`: [${oldPlugin.commit}...${newPlugin.commit}](https://github.com/${oldPluginURL.user}/${oldPluginURL.repo}/compare/${oldPlugin.commit}...${user}:${newPlugin.commit})`);
 			} else if (file.status == "added") {
 				diffLines.push(`New plugin \`${pluginName}\`: https://github.com/${user}/${repo}/tree/${newPlugin.commit}`);
+				diffLines.push(`https://github.com/runelite/example-plugin/compare/master...${user}:${repo}:${newPlugin.commit}`);
 			} else if (file.status == "renamed") {
 				let oldPluginName = ((file as any).previous_filename as string).replace("plugins/", "");
 				let oldPlugin = readKV(await github.request(`https://github.com/${context.repo().owner}/${context.repo().repo}/raw/master/plugins/${oldPluginName}`));


### PR DESCRIPTION
adds a link to diff new plugins against the plugin template alongside the link to the full repo.

Didn't test actual bot execution but here is an example intended output link:
https://github.com/runelite/example-plugin/compare/master...sreilly64:yama-utilities:f44fd524ddf1af6dc49ad07e1762ba2721b0e824